### PR TITLE
Fix "must be str, not PosixPath" in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ class InstallHook(setuptools.command.install.install):
                 continue
             content = file.read_text()
             for key, val in substkeys.items():
-                content = content.replace(f"!!{key}!!", val)
+                content = content.replace(f"!!{key}!!", str(val))
             file.with_suffix("").write_text(content)
         super().run()
 


### PR DESCRIPTION
If I try to compile your current GIT version on Arch, then I get a error in the string replacement, that the second argument has to be of type "str" and not "PosixPath".

This simple fix allows me to compile. Please have a look and merge if the fix is OK.